### PR TITLE
feat(supabase): Add Supabase deployment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ Awesome DeFi apps you can deploy on Akash
 ### Databases
 
 - [redis](redis)
+- [Supabase](supabase)
 
 ### Video Conferencing
 

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -36,6 +36,8 @@ This template deploys [Supabase](https://supabase.com/), an open source Firebase
    - For `SUPABASE_ANON_KEY` and `ANON_KEY`: Create an anonymous role JWT
    - For `SUPABASE_SERVICE_KEY` and `SERVICE_KEY`: Create a service role JWT
    
+   **Important:** Both the anonymous and service tokens must be signed with the same `JWT_SECRET` you created in step 1.
+   
    You can use the [jwt.io](https://jwt.io/) website with your JWT secret to create these tokens with the appropriate payloads.
 
 3. Consider changing the default database credentials for production use.
@@ -72,9 +74,31 @@ provider-services send-manifest deploy.yaml --dseq <DEPLOYMENT_ID> --provider <P
 provider-services lease-status --dseq <DEPLOYMENT_ID> --provider <PROVIDER_ADDRESS> --from <YOUR_KEY_NAME>
 ```
 
+### Post-Deployment Configuration (Important)
+
+After deployment, you must update the following environment variables in your `deploy.yaml` file with your actual Akash ingress URL, then redeploy:
+
+- `PUBLIC_URL`: Set to `https://<deployment-id>.ingress.akash.network`
+- `SUPABASE_PUBLIC_URL`: Set to `https://<deployment-id>.ingress.akash.network`
+- `API_EXTERNAL_URL`: Set to `https://<deployment-id>.ingress.akash.network`
+- `GOTRUE_SITE_URL`: Set to `https://<deployment-id>.ingress.akash.network`
+
+Without this step, authentication and other features may not work properly.
+
 ## Access and Configuration
 
-Once deployed, you can access the Supabase Studio at the provided URI for the `studio` service. You'll need to use the keys you configured in the deployment YAML.
+Once deployed, you can access the Supabase Studio at:
+
+```
+https://<deployment-id>.ingress.akash.network
+```
+
+For example, if your deployment ID is `123456`, the URL would be:
+```
+https://123456.ingress.akash.network
+```
+
+You'll need to use the keys you configured in the deployment YAML for authentication.
 
 ## Data Persistence
 

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -18,6 +18,28 @@ This template deploys [Supabase](https://supabase.com/), an open source Firebase
 - Akash account with funds
 - Akash CLI installed and configured
 
+### Security Configuration (Important)
+
+⚠️ **Before deploying:** You must edit the `deploy.yaml` file to replace the placeholder values with your own secure keys and secrets:
+
+1. Generate a JWT secret (at least 32 characters) for these fields:
+   - `PGRST_JWT_SECRET`
+   - `GOTRUE_JWT_SECRET`
+   - `JWT_SECRET`
+
+   You can generate a secure random string with:
+   ```bash
+   openssl rand -base64 32
+   ```
+
+2. Generate JWT tokens for Supabase authentication:
+   - For `SUPABASE_ANON_KEY` and `ANON_KEY`: Create an anonymous role JWT
+   - For `SUPABASE_SERVICE_KEY` and `SERVICE_KEY`: Create a service role JWT
+   
+   You can use the [jwt.io](https://jwt.io/) website with your JWT secret to create these tokens with the appropriate payloads.
+
+3. Consider changing the default database credentials for production use.
+
 ### Deploying on Akash
 
 1. Create a deployment with the provided SDL:
@@ -52,21 +74,7 @@ provider-services lease-status --dseq <DEPLOYMENT_ID> --provider <PROVIDER_ADDRE
 
 ## Access and Configuration
 
-Once deployed, you can access the Supabase Studio at the provided URI for the `studio` service. By default, the following credentials are available:
-
-- **Supabase Anon Key**: `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE`
-- **Supabase Service Key**: `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.knhOrPKq1GjejLQr7fuiRBFILwzKxrpxBvzYEJXKy8E`
-- **JWT Secret**: `super-secret-jwt-token-with-at-least-32-characters`
-
-⚠️ **Important Security Notice**: The deployment uses default keys and secrets for demonstration purposes. For production use, you should modify the `deploy.yaml` file to use your own secure keys and secrets.
-
-### Modifying Security Settings
-
-For a production deployment, you should change these values in the `deploy.yaml` file:
-
-1. `JWT_SECRET` and `PGRST_JWT_SECRET` - Generate a secure random string
-2. Database passwords
-3. Generate new anon and service keys
+Once deployed, you can access the Supabase Studio at the provided URI for the `studio` service. You'll need to use the keys you configured in the deployment YAML.
 
 ## Data Persistence
 

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,96 @@
+# Supabase on Akash
+
+This template deploys [Supabase](https://supabase.com/), an open source Firebase alternative offering all the backend features developers need to build a product: PostgreSQL database, authentication, instant APIs, realtime subscriptions, and storage.
+
+## Features
+
+- PostgreSQL database
+- RESTful API with PostgREST
+- Authentication with GoTrue
+- Realtime subscriptions
+- File storage
+- Supabase Studio (Web UI)
+
+## Deployment
+
+### Prerequisites
+
+- Akash account with funds
+- Akash CLI installed and configured
+
+### Deploying on Akash
+
+1. Create a deployment with the provided SDL:
+
+```bash
+provider-services tx deployment create deploy.yaml --from <YOUR_KEY_NAME>
+```
+
+2. List deployments and find your deployment ID:
+
+```bash
+provider-services query deployment list --owner <YOUR_AKASH_ADDRESS>
+```
+
+3. Create a lease:
+
+```bash
+provider-services tx market lease create --dseq <DEPLOYMENT_ID> --provider <PROVIDER_ADDRESS> --from <YOUR_KEY_NAME>
+```
+
+4. Send manifest:
+
+```bash
+provider-services send-manifest deploy.yaml --dseq <DEPLOYMENT_ID> --provider <PROVIDER_ADDRESS> --from <YOUR_KEY_NAME>
+```
+
+5. Get lease status (includes your Supabase Studio URL):
+
+```bash
+provider-services lease-status --dseq <DEPLOYMENT_ID> --provider <PROVIDER_ADDRESS> --from <YOUR_KEY_NAME>
+```
+
+## Access and Configuration
+
+Once deployed, you can access the Supabase Studio at the provided URI for the `studio` service. By default, the following credentials are available:
+
+- **Supabase Anon Key**: `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE`
+- **Supabase Service Key**: `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.knhOrPKq1GjejLQr7fuiRBFILwzKxrpxBvzYEJXKy8E`
+- **JWT Secret**: `super-secret-jwt-token-with-at-least-32-characters`
+
+⚠️ **Important Security Notice**: The deployment uses default keys and secrets for demonstration purposes. For production use, you should modify the `deploy.yaml` file to use your own secure keys and secrets.
+
+### Modifying Security Settings
+
+For a production deployment, you should change these values in the `deploy.yaml` file:
+
+1. `JWT_SECRET` and `PGRST_JWT_SECRET` - Generate a secure random string
+2. Database passwords
+3. Generate new anon and service keys
+
+## Data Persistence
+
+This deployment includes persistent storage for:
+
+- PostgreSQL data at `/var/lib/postgresql/data`
+- Storage API files at `/var/lib/storage`
+
+Your data should persist across restarts as long as the lease is maintained.
+
+## Connecting to Your Supabase Instance
+
+Once Supabase is running, you can use the Studio web interface to:
+
+1. Create and manage database tables
+2. Set up authentication providers
+3. Create API keys
+4. Configure storage buckets
+5. View realtime logs and more
+
+For client applications, use the public URL and anon key to connect using the [Supabase client libraries](https://github.com/supabase/supabase-js).
+
+## Additional Resources
+
+- [Supabase Documentation](https://supabase.com/docs)
+- [Supabase GitHub](https://github.com/supabase/supabase)
+- [Akash Network Documentation](https://akash.network/docs/)

--- a/supabase/config.json
+++ b/supabase/config.json
@@ -1,0 +1,18 @@
+{
+  "logo": {
+    "url": "https://supabase.com/dashboard/img/supabase-logo.svg"
+  },
+  "display": {
+    "name": "Supabase",
+    "description": "Open source Firebase alternative with all the backend features developers need: PostgreSQL database, authentication, instant APIs, and realtime subscriptions."
+  },
+  "tags": [
+    "database",
+    "api",
+    "backend",
+    "postgresql",
+    "authentication",
+    "storage"
+  ]
+}
+

--- a/supabase/deploy.yaml
+++ b/supabase/deploy.yaml
@@ -3,201 +3,178 @@ version: "2.0"
 
 services:
   db:
-    image: supabase/postgres:15.1.0.73
+    image: supabase/postgres:15.1.0.147
     env:
-      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_PASSWORD=Kx9mP2vL8nQ4rT6wY3jF5hB7dN1cV0sA9eR4tU8iO2pL6kM3nX7qZ5wE1rT9yU4i
       - POSTGRES_USER=postgres
       - POSTGRES_DB=postgres
-      - PGDATA=/var/lib/postgresql/data
     expose:
       - port: 5432
         to:
-          - service: studio
-          - service: api
-    params:
-      storage:
-        data:
-          mount: /var/lib/postgresql/data
-
-  api:
-    image: supabase/postgrest:v10.1.2
-    depends_on:
-      - db
-    env:
-      - PGRST_DB_URI=postgres://postgres:postgres@db:5432/postgres
-      - PGRST_DB_SCHEMAS=public
-      - PGRST_DB_ANON_ROLE=anon
-      - PGRST_JWT_SECRET=REPLACE_WITH_YOUR_OWN_RANDOM_SECRET
-      - PGRST_LOG_LEVEL=info
-    expose:
-      - port: 3000
-        to:
-          - service: studio
-          - service: gotrue
+          - service: kong
+          - service: auth
+          - service: rest
           - service: realtime
           - service: storage
           - service: meta
 
-  studio:
-    image: supabase/studio:20230223-400b5ff
-    depends_on:
-      - db
-      - api
-      - gotrue
-      - realtime
-      - storage
-      - meta
+  kong:
+    image: kong:2.8.1
     env:
-      - STUDIO_PG_META_URL=http://meta:8080
-      - POSTGRES_PASSWORD=postgres
-      - SUPABASE_URL=http://kong:8000
-      - SUPABASE_PUBLIC_URL=${AKASH_PUBLIC_ENDPOINT_URL_HTTP}
-      - SUPABASE_ANON_KEY=REPLACE_WITH_YOUR_OWN_ANON_KEY
-      - SUPABASE_SERVICE_KEY=REPLACE_WITH_YOUR_OWN_SERVICE_KEY
+      - KONG_DATABASE=off
+      - KONG_DECLARATIVE_CONFIG=/var/lib/kong/kong.yml
+      - KONG_DNS_ORDER=LAST,A,CNAME
+      - KONG_PLUGINS=request-transformer,cors,key-auth,acl
     expose:
-      - port: 3000
+      - port: 8000
         as: 80
         to:
           - global: true
 
-  gotrue:
-    image: supabase/gotrue:v2.41.0
-    depends_on:
-      - db
+  auth:
+    image: supabase/gotrue:v2.99.0
     env:
-      - API_EXTERNAL_URL=${AKASH_PUBLIC_ENDPOINT_URL_HTTP}
       - GOTRUE_API_HOST=0.0.0.0
       - GOTRUE_API_PORT=9999
       - GOTRUE_DB_DRIVER=postgres
-      - GOTRUE_DB_DATABASE_URL=postgres://postgres:postgres@db:5432/postgres
-      - GOTRUE_SITE_URL=${AKASH_PUBLIC_ENDPOINT_URL_HTTP}
+      - GOTRUE_DB_DATABASE_URL=postgres://supabase_auth_admin:Kx9mP2vL8nQ4rT6wY3jF5hB7dN1cV0sA9eR4tU8iO2pL6kM3nX7qZ5wE1rT9yU4i@db:5432/postgres
+      - GOTRUE_SITE_URL=http://localhost:3000
       - GOTRUE_URI_ALLOW_LIST=
       - GOTRUE_DISABLE_SIGNUP=false
-      - GOTRUE_JWT_SECRET=REPLACE_WITH_YOUR_OWN_RANDOM_SECRET
-      - GOTRUE_JWT_EXP=3600
+      - GOTRUE_JWT_ADMIN_ROLES=service_role
+      - GOTRUE_JWT_AUD=authenticated
       - GOTRUE_JWT_DEFAULT_GROUP_NAME=authenticated
-      - GOTRUE_EXTERNAL_EMAIL_ENABLED=false
+      - GOTRUE_JWT_EXP=3600
+      - GOTRUE_JWT_SECRET=H7kL9mN2pQ5rS8tV1wX4yA6bC3dE0fG9hI2jK5lM8nO1pR4sT7uV0wY3zA6bD9eF
+      - GOTRUE_EXTERNAL_EMAIL_ENABLED=true
       - GOTRUE_MAILER_AUTOCONFIRM=true
-      - GOTRUE_SMS_AUTOCONFIRM=true
     expose:
       - port: 9999
         to:
-          - service: studio
+          - service: kong
+
+  rest:
+    image: postgrest/postgrest:v11.2.2
+    env:
+      - PGRST_DB_URI=postgres://authenticator:Kx9mP2vL8nQ4rT6wY3jF5hB7dN1cV0sA9eR4tU8iO2pL6kM3nX7qZ5wE1rT9yU4i@db:5432/postgres
+      - PGRST_DB_SCHEMAS=public,storage,graphql_public
+      - PGRST_DB_ANON_ROLE=anon
+      - PGRST_JWT_SECRET=H7kL9mN2pQ5rS8tV1wX4yA6bC3dE0fG9hI2jK5lM8nO1pR4sT7uV0wY3zA6bD9eF
+      - PGRST_DB_USE_LEGACY_GUCS=false
+      - PGRST_APP_SETTINGS_JWT_SECRET=H7kL9mN2pQ5rS8tV1wX4yA6bC3dE0fG9hI2jK5lM8nO1pR4sT7uV0wY3zA6bD9eF
+      - PGRST_APP_SETTINGS_JWT_EXP=3600
+    expose:
+      - port: 3000
+        to:
           - service: kong
 
   realtime:
-    image: supabase/realtime:v2.1.0
-    depends_on:
-      - db
+    image: supabase/realtime:v2.25.50
     env:
+      - PORT=4000
       - DB_HOST=db
       - DB_PORT=5432
-      - DB_USER=postgres
-      - DB_PASSWORD=postgres
+      - DB_USER=supabase_admin
+      - DB_PASSWORD=Kx9mP2vL8nQ4rT6wY3jF5hB7dN1cV0sA9eR4tU8iO2pL6kM3nX7qZ5wE1rT9yU4i
       - DB_NAME=postgres
       - DB_AFTER_CONNECT_QUERY=SET search_path TO _realtime
-      - PORT=4000
-      - JWT_SECRET=REPLACE_WITH_YOUR_OWN_RANDOM_SECRET
-      - SECURE_CHANNELS=false
-      - SLOT_NAME=supabase_realtime
-      - TEMPORARY_SLOT=true
-      - DB_SSL=false
+      - DB_ENC_KEY=supabaserealtime
+      - API_JWT_SECRET=H7kL9mN2pQ5rS8tV1wX4yA6bC3dE0fG9hI2jK5lM8nO1pR4sT7uV0wY3zA6bD9eF
+      - FLY_ALLOC_ID=fly123
+      - FLY_APP_NAME=realtime
+      - SECRET_KEY_BASE=UpNVntn3cDxHJpq99YMc1T1AQgQpc8kfYTuRgBiYa15BLrx8etQoXz3gZv1/u2oq
+      - ERL_AFLAGS=-proto_dist inet_tcp
+      - ENABLE_TAILSCALE=false
+      - DNS_NODES=
     expose:
       - port: 4000
         to:
-          - service: studio
           - service: kong
 
   storage:
-    image: supabase/storage-api:v0.28.0
-    depends_on:
-      - db
-      - api
+    image: supabase/storage-api:v0.43.11
     env:
-      - ANON_KEY=REPLACE_WITH_YOUR_OWN_ANON_KEY
-      - SERVICE_KEY=REPLACE_WITH_YOUR_OWN_SERVICE_KEY
-      - POSTGREST_URL=http://api:3000
-      - PGRST_JWT_SECRET=REPLACE_WITH_YOUR_OWN_RANDOM_SECRET
-      - DATABASE_URL=postgres://postgres:postgres@db:5432/postgres
-      - PGOPTIONS=-c search_path=storage,public
-      - FILE_SIZE_LIMIT=50000000
+      - ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+      - SERVICE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
+      - POSTGREST_URL=http://rest:3000
+      - PGRST_JWT_SECRET=H7kL9mN2pQ5rS8tV1wX4yA6bC3dE0fG9hI2jK5lM8nO1pR4sT7uV0wY3zA6bD9eF
+      - DATABASE_URL=postgres://supabase_storage_admin:Kx9mP2vL8nQ4rT6wY3jF5hB7dN1cV0sA9eR4tU8iO2pL6kM3nX7qZ5wE1rT9yU4i@db:5432/postgres
+      - FILE_SIZE_LIMIT=52428800
       - STORAGE_BACKEND=file
       - FILE_STORAGE_BACKEND_PATH=/var/lib/storage
       - TENANT_ID=stub
+      - REGION=stub
+      - GLOBAL_S3_BUCKET=stub
     expose:
       - port: 5000
         to:
-          - service: studio
           - service: kong
-    params:
-      storage:
-        storage-files:
-          mount: /var/lib/storage
 
   meta:
-    image: supabase/postgres-meta:v0.60.8
-    depends_on:
-      - db
+    image: supabase/postgres-meta:v0.68.0
     env:
       - PG_META_PORT=8080
       - PG_META_DB_HOST=db
-      - PG_META_DB_PASSWORD=postgres
       - PG_META_DB_PORT=5432
       - PG_META_DB_NAME=postgres
       - PG_META_DB_USER=postgres
+      - PG_META_DB_PASSWORD=Kx9mP2vL8nQ4rT6wY3jF5hB7dN1cV0sA9eR4tU8iO2pL6kM3nX7qZ5wE1rT9yU4i
     expose:
       - port: 8080
         to:
+          - service: kong
           - service: studio
 
-  kong:
-    image: kong:2.8.1
-    depends_on:
-      - api
-      - gotrue
-      - storage
-      - realtime
+  studio:
+    image: supabase/studio:20231123-64ebc87
     env:
-      - KONG_DATABASE=off
-      - KONG_DECLARATIVE_CONFIG=/kong.yml
+      - STUDIO_PG_META_URL=http://meta:8080
+      - POSTGRES_PASSWORD=Kx9mP2vL8nQ4rT6wY3jF5hB7dN1cV0sA9eR4tU8iO2pL6kM3nX7qZ5wE1rT9yU4i
+      - DEFAULT_ORGANIZATION_NAME=Akash Supabase
+      - DEFAULT_PROJECT_NAME=My Project
+      - SUPABASE_URL=http://kong:8000
+      - SUPABASE_PUBLIC_URL=https://REPLACE_WITH_YOUR_DEPLOYMENT_URL
+      - SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+      - SUPABASE_SERVICE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
     expose:
-      - port: 8000
+      - port: 3000
+        as: 3000
         to:
-          - service: studio
-    cmd:
-      - kong
-      - start
-      - -c
-      - /kong.yml
+          - global: true
 
 profiles:
   compute:
     db:
       resources:
         cpu:
-          units: 1.0
+          units: 2.0
         memory:
-          size: 2Gi
-      storage:
-        data:
-          size: 10Gi
-    api:
+          size: 4Gi
+        storage:
+          size: 20Gi
+    kong:
       resources:
         cpu:
           units: 0.5
         memory:
           size: 512Mi
-    studio:
+        storage:
+          size: 512Mi
+    auth:
       resources:
         cpu:
           units: 0.5
         memory:
           size: 512Mi
-    gotrue:
+        storage:
+          size: 512Mi
+    rest:
       resources:
         cpu:
           units: 0.5
         memory:
+          size: 512Mi
+        storage:
           size: 512Mi
     realtime:
       resources:
@@ -205,12 +182,14 @@ profiles:
           units: 0.5
         memory:
           size: 512Mi
+        storage:
+          size: 512Mi
     storage:
       resources:
         cpu:
           units: 0.5
         memory:
-          size: 512Mi
+          size: 1Gi
         storage:
           size: 10Gi
     meta:
@@ -219,74 +198,75 @@ profiles:
           units: 0.5
         memory:
           size: 512Mi
-    kong:
+        storage:
+          size: 512Mi
+    studio:
       resources:
         cpu:
           units: 0.5
         memory:
           size: 512Mi
+        storage:
+          size: 512Mi
+
   placement:
-    akash:
-      attributes:
-        host: akash
-      signedBy:
-        anyOf:
-          - akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63
+    dcloud:
       pricing:
         db:
           denom: uakt
-          amount: 10000
-        api:
-          denom: uakt
-          amount: 5000
-        studio:
-          denom: uakt
-          amount: 5000
-        gotrue:
-          denom: uakt
-          amount: 5000
-        realtime:
-          denom: uakt
-          amount: 5000
-        storage:
-          denom: uakt
-          amount: 5000
-        meta:
-          denom: uakt
-          amount: 5000
+          amount: 1000
         kong:
           denom: uakt
-          amount: 5000
+          amount: 1000
+        auth:
+          denom: uakt
+          amount: 1000
+        rest:
+          denom: uakt
+          amount: 1000
+        realtime:
+          denom: uakt
+          amount: 1000
+        storage:
+          denom: uakt
+          amount: 1000
+        meta:
+          denom: uakt
+          amount: 1000
+        studio:
+          denom: uakt
+          amount: 1000
+
 deployment:
   db:
-    akash:
+    dcloud:
       profile: db
       count: 1
-  api:
-    akash:
-      profile: api
+  kong:
+    dcloud:
+      profile: kong
       count: 1
-  studio:
-    akash:
-      profile: studio
+  auth:
+    dcloud:
+      profile: auth
       count: 1
-  gotrue:
-    akash:
-      profile: gotrue
+  rest:
+    dcloud:
+      profile: rest
       count: 1
   realtime:
-    akash:
+    dcloud:
       profile: realtime
       count: 1
   storage:
-    akash:
+    dcloud:
       profile: storage
       count: 1
   meta:
-    akash:
+    dcloud:
       profile: meta
       count: 1
-  kong:
-    akash:
-      profile: kong
+  studio:
+    dcloud:
+      profile: studio
       count: 1

--- a/supabase/deploy.yaml
+++ b/supabase/deploy.yaml
@@ -4,202 +4,183 @@ version: "2.0"
 services:
   db:
     image: supabase/postgres:15.1.0.147
-    env:
-      - POSTGRES_PASSWORD=Kx9mP2vL8nQ4rT6wY3jF5hB7dN1cV0sA9eR4tU8iO2pL6kM3nX7qZ5wE1rT9yU4i
-      - POSTGRES_USER=postgres
-      - POSTGRES_DB=postgres
     expose:
       - port: 5432
         to:
-          - service: kong
-          - service: auth
-          - service: rest
-          - service: realtime
+          - service: studio
+          - service: api
+          - service: gotrue
           - service: storage
           - service: meta
-
-  kong:
-    image: kong:2.8.1
+    command:
+      - /bin/sh
+      - -c
+      - |
+        chown -R postgres:postgres /var/lib/postgresql/data || true
+        chmod 700 /var/lib/postgresql/data || true
+        exec docker-entrypoint.sh postgres -c listen_addresses='*'
     env:
-      - KONG_DATABASE=off
-      - KONG_DECLARATIVE_CONFIG=/var/lib/kong/kong.yml
-      - KONG_DNS_ORDER=LAST,A,CNAME
-      - KONG_PLUGINS=request-transformer,cors,key-auth,acl
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=${POSTGRES_DB}
+      - PGDATA=/var/lib/postgresql/data/pgdata
+    params:
+      storage:
+        data:
+          mount: /var/lib/postgresql/data
+          readOnly: false
+
+  api:
+    image: postgrest/postgrest:v12.2.12
+    depends_on:
+      - db
     expose:
-      - port: 8000
+      - port: 3000
+        to:
+          - service: studio
+          - service: gotrue
+          - service: storage
+          - service: meta
+    env:
+      - PGRST_DB_URI=postgres://postgres:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      - PGRST_DB_SCHEMAS=public
+      - PGRST_DB_ANON_ROLE=anon
+      - PGRST_JWT_SECRET=${JWT_SECRET}
+      - PGRST_LOG_LEVEL=info
+
+  studio:
+    image: supabase/studio:20241029-46e1e40
+    depends_on:
+      - db
+      - api
+      - gotrue
+      - storage
+      - meta
+    expose:
+      - port: 3000
         as: 80
         to:
           - global: true
-
-  auth:
-    image: supabase/gotrue:v2.99.0
     env:
-      - GOTRUE_API_HOST=0.0.0.0
-      - GOTRUE_API_PORT=9999
-      - GOTRUE_DB_DRIVER=postgres
-      - GOTRUE_DB_DATABASE_URL=postgres://supabase_auth_admin:Kx9mP2vL8nQ4rT6wY3jF5hB7dN1cV0sA9eR4tU8iO2pL6kM3nX7qZ5wE1rT9yU4i@db:5432/postgres
-      - GOTRUE_SITE_URL=http://localhost:3000
-      - GOTRUE_URI_ALLOW_LIST=
-      - GOTRUE_DISABLE_SIGNUP=false
-      - GOTRUE_JWT_ADMIN_ROLES=service_role
-      - GOTRUE_JWT_AUD=authenticated
-      - GOTRUE_JWT_DEFAULT_GROUP_NAME=authenticated
-      - GOTRUE_JWT_EXP=3600
-      - GOTRUE_JWT_SECRET=H7kL9mN2pQ5rS8tV1wX4yA6bC3dE0fG9hI2jK5lM8nO1pR4sT7uV0wY3zA6bD9eF
-      - GOTRUE_EXTERNAL_EMAIL_ENABLED=true
-      - GOTRUE_MAILER_AUTOCONFIRM=true
+      - STUDIO_PG_META_URL=http://meta:8080
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - SUPABASE_URL=http://api:3000
+      - SUPABASE_PUBLIC_URL=${PUBLIC_URL}
+      - SUPABASE_ANON_KEY=${ANON_KEY}
+      - SUPABASE_SERVICE_KEY=${SERVICE_KEY}
+
+  gotrue:
+    image: supabase/gotrue:v2.180.0
+    depends_on:
+      - db
     expose:
       - port: 9999
         to:
-          - service: kong
-
-  rest:
-    image: postgrest/postgrest:v11.2.2
+          - service: studio
+    command:
+      - /bin/sh
+      - -c
+      - |
+        echo "Waiting for database initialization..."
+        sleep 120
+        echo "Starting GoTrue..."
+        exec gotrue
     env:
-      - PGRST_DB_URI=postgres://authenticator:Kx9mP2vL8nQ4rT6wY3jF5hB7dN1cV0sA9eR4tU8iO2pL6kM3nX7qZ5wE1rT9yU4i@db:5432/postgres
-      - PGRST_DB_SCHEMAS=public,storage,graphql_public
-      - PGRST_DB_ANON_ROLE=anon
-      - PGRST_JWT_SECRET=H7kL9mN2pQ5rS8tV1wX4yA6bC3dE0fG9hI2jK5lM8nO1pR4sT7uV0wY3zA6bD9eF
-      - PGRST_DB_USE_LEGACY_GUCS=false
-      - PGRST_APP_SETTINGS_JWT_SECRET=H7kL9mN2pQ5rS8tV1wX4yA6bC3dE0fG9hI2jK5lM8nO1pR4sT7uV0wY3zA6bD9eF
-      - PGRST_APP_SETTINGS_JWT_EXP=3600
-    expose:
-      - port: 3000
-        to:
-          - service: kong
-
-  realtime:
-    image: supabase/realtime:v2.25.50
-    env:
-      - PORT=4000
-      - DB_HOST=db
-      - DB_PORT=5432
-      - DB_USER=supabase_admin
-      - DB_PASSWORD=Kx9mP2vL8nQ4rT6wY3jF5hB7dN1cV0sA9eR4tU8iO2pL6kM3nX7qZ5wE1rT9yU4i
-      - DB_NAME=postgres
-      - DB_AFTER_CONNECT_QUERY=SET search_path TO _realtime
-      - DB_ENC_KEY=supabaserealtime
-      - API_JWT_SECRET=H7kL9mN2pQ5rS8tV1wX4yA6bC3dE0fG9hI2jK5lM8nO1pR4sT7uV0wY3zA6bD9eF
-      - FLY_ALLOC_ID=fly123
-      - FLY_APP_NAME=realtime
-      - SECRET_KEY_BASE=UpNVntn3cDxHJpq99YMc1T1AQgQpc8kfYTuRgBiYa15BLrx8etQoXz3gZv1/u2oq
-      - ERL_AFLAGS=-proto_dist inet_tcp
-      - ENABLE_TAILSCALE=false
-      - DNS_NODES=
-    expose:
-      - port: 4000
-        to:
-          - service: kong
+      - API_EXTERNAL_URL=${PUBLIC_URL}
+      - GOTRUE_API_HOST=0.0.0.0
+      - GOTRUE_API_PORT=9999
+      - GOTRUE_DB_DRIVER=postgres
+      - GOTRUE_DB_DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      - GOTRUE_SITE_URL=${PUBLIC_URL}
+      - GOTRUE_URI_ALLOW_LIST=${ALLOWED_REDIRECT_URLS}
+      - GOTRUE_DISABLE_SIGNUP=${DISABLE_SIGNUP}
+      - GOTRUE_JWT_SECRET=${JWT_SECRET}
+      - GOTRUE_JWT_EXP=3600
+      - GOTRUE_JWT_DEFAULT_GROUP_NAME=authenticated
+      - GOTRUE_EXTERNAL_EMAIL_ENABLED=false
+      - GOTRUE_MAILER_AUTOCONFIRM=true
+      - GOTRUE_SMS_AUTOCONFIRM=true
 
   storage:
-    image: supabase/storage-api:v0.43.11
-    env:
-      - ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
-      - SERVICE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
-      - POSTGREST_URL=http://rest:3000
-      - PGRST_JWT_SECRET=H7kL9mN2pQ5rS8tV1wX4yA6bC3dE0fG9hI2jK5lM8nO1pR4sT7uV0wY3zA6bD9eF
-      - DATABASE_URL=postgres://supabase_storage_admin:Kx9mP2vL8nQ4rT6wY3jF5hB7dN1cV0sA9eR4tU8iO2pL6kM3nX7qZ5wE1rT9yU4i@db:5432/postgres
-      - FILE_SIZE_LIMIT=52428800
-      - STORAGE_BACKEND=file
-      - FILE_STORAGE_BACKEND_PATH=/var/lib/storage
-      - TENANT_ID=stub
-      - REGION=stub
-      - GLOBAL_S3_BUCKET=stub
+    image: supabase/storage-api:v1.24.7
+    depends_on:
+      - db
+      - api
     expose:
       - port: 5000
         to:
-          - service: kong
+          - service: studio
+    command:
+      - /bin/sh
+      - -c
+      - |
+        echo "Waiting for database and API..."
+        sleep 130
+        echo "Starting Storage API..."
+        exec node dist/app.js
+    env:
+      - ANON_KEY=${ANON_KEY}
+      - SERVICE_KEY=${SERVICE_KEY}
+      - POSTGREST_URL=http://api:3000
+      - PGRST_JWT_SECRET=${JWT_SECRET}
+      - DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      - FILE_SIZE_LIMIT=50000000
+      - STORAGE_BACKEND=file
+      - FILE_STORAGE_BACKEND_PATH=/var/lib/storage
+      - TENANT_ID=stub
+    params:
+      storage:
+        storage-files:
+          mount: /var/lib/storage
+          readOnly: false
 
   meta:
-    image: supabase/postgres-meta:v0.68.0
-    env:
-      - PG_META_PORT=8080
-      - PG_META_DB_HOST=db
-      - PG_META_DB_PORT=5432
-      - PG_META_DB_NAME=postgres
-      - PG_META_DB_USER=postgres
-      - PG_META_DB_PASSWORD=Kx9mP2vL8nQ4rT6wY3jF5hB7dN1cV0sA9eR4tU8iO2pL6kM3nX7qZ5wE1rT9yU4i
+    image: supabase/postgres-meta:v0.89.3
+    depends_on:
+      - db
     expose:
       - port: 8080
         to:
-          - service: kong
           - service: studio
-
-  studio:
-    image: supabase/studio:20231123-64ebc87
+    command:
+      - /bin/sh
+      - -c
+      - |
+        echo "Waiting for database..."
+        sleep 110
+        echo "Starting Meta API..."
+        exec node dist/server/app.js
     env:
-      - STUDIO_PG_META_URL=http://meta:8080
-      - POSTGRES_PASSWORD=Kx9mP2vL8nQ4rT6wY3jF5hB7dN1cV0sA9eR4tU8iO2pL6kM3nX7qZ5wE1rT9yU4i
-      - DEFAULT_ORGANIZATION_NAME=Akash Supabase
-      - DEFAULT_PROJECT_NAME=My Project
-      - SUPABASE_URL=http://kong:8000
-      - SUPABASE_PUBLIC_URL=https://REPLACE_WITH_YOUR_DEPLOYMENT_URL
-      - SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
-      - SUPABASE_SERVICE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
-    expose:
-      - port: 3000
-        as: 3000
-        to:
-          - global: true
+      - PG_META_PORT=8080
+      - PG_META_DB_HOST=db
+      - PG_META_DB_PASSWORD=${POSTGRES_PASSWORD}
+      - PG_META_DB_PORT=5432
+      - PG_META_DB_NAME=${POSTGRES_DB}
+      - PG_META_DB_USER=postgres
 
 profiles:
   compute:
     db:
       resources:
         cpu:
-          units: 2.0
+          units: 1
         memory:
-          size: 4Gi
+          size: 2Gi
         storage:
-          size: 20Gi
-    kong:
+          - size: 1Gi
+          - name: data
+            size: 10Gi
+            attributes:
+              persistent: true
+              class: beta3
+    api:
       resources:
         cpu:
           units: 0.5
         memory:
           size: 512Mi
         storage:
-          size: 512Mi
-    auth:
-      resources:
-        cpu:
-          units: 0.5
-        memory:
-          size: 512Mi
-        storage:
-          size: 512Mi
-    rest:
-      resources:
-        cpu:
-          units: 0.5
-        memory:
-          size: 512Mi
-        storage:
-          size: 512Mi
-    realtime:
-      resources:
-        cpu:
-          units: 0.5
-        memory:
-          size: 512Mi
-        storage:
-          size: 512Mi
-    storage:
-      resources:
-        cpu:
-          units: 0.5
-        memory:
-          size: 1Gi
-        storage:
-          size: 10Gi
-    meta:
-      resources:
-        cpu:
-          units: 0.5
-        memory:
-          size: 512Mi
-        storage:
-          size: 512Mi
+          - size: 1Gi
     studio:
       resources:
         cpu:
@@ -207,66 +188,81 @@ profiles:
         memory:
           size: 512Mi
         storage:
+          - size: 1Gi
+    gotrue:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
           size: 512Mi
+        storage:
+          - size: 1Gi
+    storage:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          - size: 1Gi
+          - name: storage-files
+            size: 10Gi
+            attributes:
+              persistent: true
+              class: beta3
+    meta:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          - size: 1Gi
 
   placement:
-    dcloud:
+    akash:
       pricing:
         db:
           denom: uakt
-          amount: 1000
-        kong:
+          amount: 10000
+        api:
           denom: uakt
-          amount: 1000
-        auth:
-          denom: uakt
-          amount: 1000
-        rest:
-          denom: uakt
-          amount: 1000
-        realtime:
-          denom: uakt
-          amount: 1000
-        storage:
-          denom: uakt
-          amount: 1000
-        meta:
-          denom: uakt
-          amount: 1000
+          amount: 5000
         studio:
           denom: uakt
-          amount: 1000
+          amount: 5000
+        gotrue:
+          denom: uakt
+          amount: 5000
+        storage:
+          denom: uakt
+          amount: 5000
+        meta:
+          denom: uakt
+          amount: 5000
 
 deployment:
   db:
-    dcloud:
+    akash:
       profile: db
       count: 1
-  kong:
-    dcloud:
-      profile: kong
+  api:
+    akash:
+      profile: api
       count: 1
-  auth:
-    dcloud:
-      profile: auth
+  studio:
+    akash:
+      profile: studio
       count: 1
-  rest:
-    dcloud:
-      profile: rest
-      count: 1
-  realtime:
-    dcloud:
-      profile: realtime
+  gotrue:
+    akash:
+      profile: gotrue
       count: 1
   storage:
-    dcloud:
+    akash:
       profile: storage
       count: 1
   meta:
-    dcloud:
+    akash:
       profile: meta
-      count: 1
-  studio:
-    dcloud:
-      profile: studio
       count: 1

--- a/supabase/deploy.yaml
+++ b/supabase/deploy.yaml
@@ -27,7 +27,7 @@ services:
       - PGRST_DB_URI=postgres://postgres:postgres@db:5432/postgres
       - PGRST_DB_SCHEMAS=public
       - PGRST_DB_ANON_ROLE=anon
-      - PGRST_JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters
+      - PGRST_JWT_SECRET=REPLACE_WITH_YOUR_OWN_RANDOM_SECRET
       - PGRST_LOG_LEVEL=info
     expose:
       - port: 3000
@@ -52,8 +52,8 @@ services:
       - POSTGRES_PASSWORD=postgres
       - SUPABASE_URL=http://kong:8000
       - SUPABASE_PUBLIC_URL=${AKASH_PUBLIC_ENDPOINT_URL_HTTP}
-      - SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE
-      - SUPABASE_SERVICE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.knhOrPKq1GjejLQr7fuiRBFILwzKxrpxBvzYEJXKy8E
+      - SUPABASE_ANON_KEY=REPLACE_WITH_YOUR_OWN_ANON_KEY
+      - SUPABASE_SERVICE_KEY=REPLACE_WITH_YOUR_OWN_SERVICE_KEY
     expose:
       - port: 3000
         as: 80
@@ -73,7 +73,7 @@ services:
       - GOTRUE_SITE_URL=${AKASH_PUBLIC_ENDPOINT_URL_HTTP}
       - GOTRUE_URI_ALLOW_LIST=
       - GOTRUE_DISABLE_SIGNUP=false
-      - GOTRUE_JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters
+      - GOTRUE_JWT_SECRET=REPLACE_WITH_YOUR_OWN_RANDOM_SECRET
       - GOTRUE_JWT_EXP=3600
       - GOTRUE_JWT_DEFAULT_GROUP_NAME=authenticated
       - GOTRUE_EXTERNAL_EMAIL_ENABLED=false
@@ -97,7 +97,7 @@ services:
       - DB_NAME=postgres
       - DB_AFTER_CONNECT_QUERY=SET search_path TO _realtime
       - PORT=4000
-      - JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters
+      - JWT_SECRET=REPLACE_WITH_YOUR_OWN_RANDOM_SECRET
       - SECURE_CHANNELS=false
       - SLOT_NAME=supabase_realtime
       - TEMPORARY_SLOT=true
@@ -114,10 +114,10 @@ services:
       - db
       - api
     env:
-      - ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE
-      - SERVICE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.knhOrPKq1GjejLQr7fuiRBFILwzKxrpxBvzYEJXKy8E
+      - ANON_KEY=REPLACE_WITH_YOUR_OWN_ANON_KEY
+      - SERVICE_KEY=REPLACE_WITH_YOUR_OWN_SERVICE_KEY
       - POSTGREST_URL=http://api:3000
-      - PGRST_JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters
+      - PGRST_JWT_SECRET=REPLACE_WITH_YOUR_OWN_RANDOM_SECRET
       - DATABASE_URL=postgres://postgres:postgres@db:5432/postgres
       - PGOPTIONS=-c search_path=storage,public
       - FILE_SIZE_LIMIT=50000000

--- a/supabase/deploy.yaml
+++ b/supabase/deploy.yaml
@@ -1,0 +1,291 @@
+---
+version: "2.0"
+
+services:
+  db:
+    image: supabase/postgres:15.1.0.73
+    env:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=postgres
+      - PGDATA=/var/lib/postgresql/data
+    expose:
+      - port: 5432
+        to:
+          - service: studio
+          - service: api
+    params:
+      storage:
+        data:
+          mount: /var/lib/postgresql/data
+
+  api:
+    image: supabase/postgrest:v10.1.2
+    depends_on:
+      - db
+    env:
+      - PGRST_DB_URI=postgres://postgres:postgres@db:5432/postgres
+      - PGRST_DB_SCHEMAS=public
+      - PGRST_DB_ANON_ROLE=anon
+      - PGRST_JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters
+      - PGRST_LOG_LEVEL=info
+    expose:
+      - port: 3000
+        to:
+          - service: studio
+          - service: gotrue
+          - service: realtime
+          - service: storage
+          - service: meta
+
+  studio:
+    image: supabase/studio:20230223-400b5ff
+    depends_on:
+      - db
+      - api
+      - gotrue
+      - realtime
+      - storage
+      - meta
+    env:
+      - STUDIO_PG_META_URL=http://meta:8080
+      - POSTGRES_PASSWORD=postgres
+      - SUPABASE_URL=http://kong:8000
+      - SUPABASE_PUBLIC_URL=${AKASH_PUBLIC_ENDPOINT_URL_HTTP}
+      - SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE
+      - SUPABASE_SERVICE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.knhOrPKq1GjejLQr7fuiRBFILwzKxrpxBvzYEJXKy8E
+    expose:
+      - port: 3000
+        as: 80
+        to:
+          - global: true
+
+  gotrue:
+    image: supabase/gotrue:v2.41.0
+    depends_on:
+      - db
+    env:
+      - API_EXTERNAL_URL=${AKASH_PUBLIC_ENDPOINT_URL_HTTP}
+      - GOTRUE_API_HOST=0.0.0.0
+      - GOTRUE_API_PORT=9999
+      - GOTRUE_DB_DRIVER=postgres
+      - GOTRUE_DB_DATABASE_URL=postgres://postgres:postgres@db:5432/postgres
+      - GOTRUE_SITE_URL=${AKASH_PUBLIC_ENDPOINT_URL_HTTP}
+      - GOTRUE_URI_ALLOW_LIST=
+      - GOTRUE_DISABLE_SIGNUP=false
+      - GOTRUE_JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters
+      - GOTRUE_JWT_EXP=3600
+      - GOTRUE_JWT_DEFAULT_GROUP_NAME=authenticated
+      - GOTRUE_EXTERNAL_EMAIL_ENABLED=false
+      - GOTRUE_MAILER_AUTOCONFIRM=true
+      - GOTRUE_SMS_AUTOCONFIRM=true
+    expose:
+      - port: 9999
+        to:
+          - service: studio
+          - service: kong
+
+  realtime:
+    image: supabase/realtime:v2.1.0
+    depends_on:
+      - db
+    env:
+      - DB_HOST=db
+      - DB_PORT=5432
+      - DB_USER=postgres
+      - DB_PASSWORD=postgres
+      - DB_NAME=postgres
+      - DB_AFTER_CONNECT_QUERY=SET search_path TO _realtime
+      - PORT=4000
+      - JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters
+      - SECURE_CHANNELS=false
+      - SLOT_NAME=supabase_realtime
+      - TEMPORARY_SLOT=true
+      - DB_SSL=false
+    expose:
+      - port: 4000
+        to:
+          - service: studio
+          - service: kong
+
+  storage:
+    image: supabase/storage-api:v0.28.0
+    depends_on:
+      - db
+      - api
+    env:
+      - ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE
+      - SERVICE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.knhOrPKq1GjejLQr7fuiRBFILwzKxrpxBvzYEJXKy8E
+      - POSTGREST_URL=http://api:3000
+      - PGRST_JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters
+      - DATABASE_URL=postgres://postgres:postgres@db:5432/postgres
+      - PGOPTIONS=-c search_path=storage,public
+      - FILE_SIZE_LIMIT=50000000
+      - STORAGE_BACKEND=file
+      - FILE_STORAGE_BACKEND_PATH=/var/lib/storage
+      - TENANT_ID=stub
+    expose:
+      - port: 5000
+        to:
+          - service: studio
+          - service: kong
+    params:
+      storage:
+        storage-files:
+          mount: /var/lib/storage
+
+  meta:
+    image: supabase/postgres-meta:v0.60.8
+    depends_on:
+      - db
+    env:
+      - PG_META_PORT=8080
+      - PG_META_DB_HOST=db
+      - PG_META_DB_PASSWORD=postgres
+      - PG_META_DB_PORT=5432
+      - PG_META_DB_NAME=postgres
+      - PG_META_DB_USER=postgres
+    expose:
+      - port: 8080
+        to:
+          - service: studio
+
+  kong:
+    image: kong:2.8.1
+    depends_on:
+      - api
+      - gotrue
+      - storage
+      - realtime
+    env:
+      - KONG_DATABASE=off
+      - KONG_DECLARATIVE_CONFIG=/kong.yml
+    expose:
+      - port: 8000
+        to:
+          - service: studio
+    cmd:
+      - kong
+      - start
+      - -c
+      - /kong.yml
+
+profiles:
+  compute:
+    db:
+      resources:
+        cpu:
+          units: 1.0
+        memory:
+          size: 2Gi
+        storage:
+          size: 10Gi
+    api:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+    studio:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+    gotrue:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+    realtime:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+    storage:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          size: 10Gi
+    meta:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+    kong:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+  placement:
+    akash:
+      attributes:
+        host: akash
+      signedBy:
+        anyOf:
+          - akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63
+      pricing:
+        db:
+          denom: uakt
+          amount: 10000
+        api:
+          denom: uakt
+          amount: 5000
+        studio:
+          denom: uakt
+          amount: 5000
+        gotrue:
+          denom: uakt
+          amount: 5000
+        realtime:
+          denom: uakt
+          amount: 5000
+        storage:
+          denom: uakt
+          amount: 5000
+        meta:
+          denom: uakt
+          amount: 5000
+        kong:
+          denom: uakt
+          amount: 5000
+deployment:
+  db:
+    akash:
+      profile: db
+      count: 1
+  api:
+    akash:
+      profile: api
+      count: 1
+  studio:
+    akash:
+      profile: studio
+      count: 1
+  gotrue:
+    akash:
+      profile: gotrue
+      count: 1
+  realtime:
+    akash:
+      profile: realtime
+      count: 1
+  storage:
+    akash:
+      profile: storage
+      count: 1
+  meta:
+    akash:
+      profile: meta
+      count: 1
+  kong:
+    akash:
+      profile: kong
+      count: 1

--- a/supabase/deploy.yaml
+++ b/supabase/deploy.yaml
@@ -178,7 +178,8 @@ profiles:
           units: 1.0
         memory:
           size: 2Gi
-        storage:
+      storage:
+        data:
           size: 10Gi
     api:
       resources:


### PR DESCRIPTION
- Add deployment example for Supabase, the open source Firebase alternative:
- Create supabase folder with deploy.yaml for PostgreSQL, API, Studio
- Add README.md with instructions for deploying and configuring
- Include config.json with logo and metadata
- Update main README.md to add Supabase in the Databases section

This allows Akash users to easily deploy Supabase on their providers.

Closes #5 